### PR TITLE
add verbose to unittest to log more errors during build fails

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY test_ACEest_Fitness.py .
 
 # Run the unit tests. If tests fail command will 
 # exit with non zero code thus failing the build
-RUN python -m unittest test_ACEest_Fitness.py
+RUN python -m unittest -v test_ACEest_Fitness.py
 
 
 


### PR DESCRIPTION
1. unit test command made verbose for seeing error details during build fails